### PR TITLE
Ulerdogan/final-rip-7212

### DIFF
--- a/RIPS/rip-7212.md
+++ b/RIPS/rip-7212.md
@@ -4,8 +4,7 @@ title: Precompile for secp256r1 Curve Support
 description: Proposal to add precompiled contract that performs signature verifications in the “secp256r1” elliptic curve.
 author: Ulaş Erdoğan (@ulerdogan), Doğan Alpaslan (@doganalpaslan)
 discussions-to: https://ethereum-magicians.org/t/eip-7212-precompiled-for-secp256r1-curve-support/14789
-status: Last Call
-last-call-deadline: 2024-01-10
+status: Final
 type: Standards Track
 category: Core
 created: 2023-06-22

--- a/RIPS/rip-7212.md
+++ b/RIPS/rip-7212.md
@@ -31,7 +31,7 @@ Modern devices have these signing mechanisms that are designed to be more secure
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-As of `FORK_TIMESTAMP` in the integrated EVM chain, add precompiled contract `P256VERIFY` for signature verifications in the “secp256r1” elliptic curve at address `PRECOMPILED_ADDRESS` in `0x0b`.
+As of `FORK_TIMESTAMP` in the integrated EVM chain, add precompiled contract `P256VERIFY` for signature verifications in the “secp256r1” elliptic curve at address `PRECOMPILED_ADDRESS` in `0x100` (indicates 0x00...00100).
 
 ### Elliptic Curve Information
 
@@ -120,7 +120,7 @@ Another important difference is that the NIST FIPS 186-5 specification does not 
 
 Wrapper libraries **SHOULD** add a malleability check by default, with functions wrapping the raw precompile call (exact NIST FIPS 186-5 spec, without malleability check) clearly identified. For example, `P256.verifySignature` and `P256.verifySignatureWithoutMalleabilityCheck`. Adding the malleability check is straightforward and costs minimal gas.
 
-The `PRECOMPILED_ADDRESS` is chosen as `0x0b` as it is the next available address in the precompiled address set.
+The `PRECOMPILED_ADDRESS` is chosen as `0x100` as `P256VERIFY` is the first precompiled contract presented as an RIP, and the address is the first available address in the precompiled address set that is reserved for the RIP precompiles.
 
 The gas cost is proposed by comparing the performance of the `P256VERIFY` and the `ECRECOVER` precompiled contract which is implemented in the EVM at `0x01` address. It is seen that “secp256r1” signature verification is ~15% slower (elaborated in [test cases](#test-cases)) than “secp256k1” signature recovery, so `3450` gas is proposed by comparison which causes similar “mgas/op” values in both precompiled contracts.
 

--- a/RIPS/rip-7212.md
+++ b/RIPS/rip-7212.md
@@ -5,6 +5,7 @@ description: Proposal to add precompiled contract that performs signature verifi
 author: Ulaş Erdoğan (@ulerdogan), Doğan Alpaslan (@doganalpaslan)
 discussions-to: https://ethereum-magicians.org/t/eip-7212-precompiled-for-secp256r1-curve-support/14789
 status: Last Call
+last-call-deadline: 2024-01-04
 type: Standards Track
 category: Core
 created: 2023-06-22


### PR DESCRIPTION
# WHAT

This PR moves RIP-7212 to the Final status.

# WHY

The Last Call ends by today (10th of the January), there are no conflicting ideas, change requests, and feedbacks during the term.

# HOW

There is not any blocker to move the RIP into Final status.