### PR TITLE
Update rips_registry_schema.json

### DIFF
--- a/registry/rips_registry.json
+++ b/registry/rips_registry.json
@@ -3,7 +3,7 @@
     "number": "rip-7212",
     "type": "precompile",
     "address": "0x0000000000000000000000000000000000000100",
-    "chains_with_mainnet_support": [
+    "chains_with_support": [
     ]
   }
 ]

--- a/registry/rips_registry_schema.json
+++ b/registry/rips_registry_schema.json
@@ -4,7 +4,7 @@
     "type": "array",
     "items": {
       "type": "object",
-      "required": ["number", "type", "chains_with_mainnet_support"],
+      "required": ["number", "type", "chains_with_support"],
       "properties": {
         "number": {
           "type": "string"
@@ -15,7 +15,7 @@
         "address": {
           "type": "string"
         },
-        "chains_with_mainnet_support": {
+        "chains_with_support": {
           "type": "array",
           "items": {
             "type": "object",

--- a/registry/rips_registry_schema.json
+++ b/registry/rips_registry_schema.json
@@ -18,7 +18,19 @@
         "chains_with_mainnet_support": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "required" : ["name", "chainID", "activation_block"],
+            "properties" : {
+                "name": {
+                    "type": "string"
+                },
+                "chainID": {
+                    "type": "number"
+                },
+                "activation_block": {
+                    "type": "number"
+                }
+            }
           }
         }
       }


### PR DESCRIPTION
Updated Schema To Provide More Useful Information
- chain ID is better indicator than name
- activation block useful for allowing addition to registry when activation is in future / better historical resource