### PR TITLE
Update RIP-7212: Clarify return data specification

### DIFF
--- a/RIPS/rip-7212.md
+++ b/RIPS/rip-7212.md
@@ -101,9 +101,10 @@ The `P256VERIFY` precompiled contract is proposed with the following input and o
     - 32 bytes of the `s` component of the signature
     - 32 bytes of the `x` coordinate of the public key
     - 32 bytes of the `y` coordinate of the public key
-- **Output data:** 32 bytes of result data and error
-    - If the signature verification process succeeds, the `result data` returns '1' in 32 bytes format. Otherwise, it always returns null.
-    - `error` always returns null.
+
+- **Output data:**
+    - If the signature verification process succeeds, it returns 1 in 32 bytes format.
+    - If the signature verification process fails, it does not return any output data.
 
 ### Precompiled Contract Gas Usage
 

--- a/RIPS/rip-7212.md
+++ b/RIPS/rip-7212.md
@@ -102,7 +102,8 @@ The `P256VERIFY` precompiled contract is proposed with the following input and o
     - 32 bytes of the `x` coordinate of the public key
     - 32 bytes of the `y` coordinate of the public key
 - **Output data:** 32 bytes of result data and error
-    - If the signature verification process succeeds, it returns 1 in 32 bytes format.
+    - If the signature verification process succeeds, the `result data` returns '1' in 32 bytes format. Otherwise, it always returns null.
+    - `error` always returns null.
 
 ### Precompiled Contract Gas Usage
 


### PR DESCRIPTION
# WHAT

This PR clarifies the specs where return data is defined, and does not make any changes on the proposal.