### PR TITLE
RIP-7560: fix typos

### DIFF
--- a/RIPS/rip-7560.md
+++ b/RIPS/rip-7560.md
@@ -89,7 +89,7 @@ smart contracts. This, however, is impossible without an addition of Native Acco
 
 ### New Transaction Type
 
-A new [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) transaction with type AA_TX_TYPE is introduced.
+A new [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) transaction with type `AA_TX_TYPE` is introduced.
 Transactions of this type are referred to as
 "AA transactions". Their payload should be interpreted as:
 
@@ -205,7 +205,7 @@ The meanings of the `maxPriorityFeePerGas` and `maxFeePerGas` are unchanged from
 For all the existing transaction types, G_txdatazero (4 gas) and G_txdatanonzero (16 gas) per byte is
 charged for the `data` parameter.
 
-Transaction Type AA_TX_TYPE introduces the following dynamic length inputs: `executionData`, `paymasterData`,
+Transaction Type `AA_TX_TYPE` introduces the following dynamic length inputs: `executionData`, `paymasterData`,
 `deployerData`, `authorizationData`. Each of these parameters' gas cost is counted towards transaction data cost.
 This transaction data gas cost is referred to as `calldataGasUsed` and is subtracted from the `validationGasLimit`
 before execution of the transaction.
@@ -315,15 +315,15 @@ We then define the following Solidity method and the `sender` of the transaction
 
 ```solidity
 
-function validateTransaction(uint256 version, bytes32 txHash, bytes transaction) external;
+function validateTransaction(uint256 version, bytes transaction, bytes32 txHash) external;
 
 ```
 
 The gas limit of this frame is set to `validationGasLimit - senderCreationGasUsed - calldataGasUsed`.\
 The `transaction` parameter is interpreted as an ABI encoding of `TransactionTypeRIP7560`.\
-The `txHash` parameter represents the hash of the AA_TX_TYPE transaction with empty `authorizationData`,
+The `txHash` parameter represents the hash of the `AA_TX_TYPE` transaction with empty `authorizationData`,
 as defined in section
-[Calculation of Transaction Type AA_TX_TYPE hash](#calculation-of-transaction-type-aatxtype-hash).\
+[Calculation of Transaction Type `AA_TX_TYPE` hash](#calculation-of-transaction-type-aa_tx_type-hash).\
 The `version` parameter is added in order to maintain the Solidity method ID in case of changes to this struct
 in future revisions of this EIP.
 
@@ -371,8 +371,8 @@ The gas limit of this frame is set to `paymasterValidationGasLimit`.
 The amount of gas used by this frame is referred to as `paymasterValidationGasUsed`.
 
 - The `version` parameter is `VERSION`
-- The `transaction` parameter is interpreted as an ABI encoding of `TransactionTypeRIP7560`.\
-- The `txHash` parameter represents the hash of the AA_TX_TYPE transaction with empty `authorizationData`,
+- The `transaction` parameter is interpreted as an ABI encoding of `TransactionTypeRIP7560`.
+- The `txHash` parameter represents the hash of the `AA_TX_TYPE` transaction with empty `authorizationData`,
 as defined in section
 [Calculation of Transaction Type AA_TX_TYPE hash](#calculation-of-transaction-type-aatxtype-hash).
 
@@ -546,7 +546,7 @@ func validateAccountAbstractionTransaction(tx *Transaction) {
 ```
 
 In order to defend from DoS attack vectors, the block builders SHOULD consider
-the opcode banning and storage access rules described in [ERC-7562](https://eips.ethereum.org/EIPS/eips/eip-7562).
+the opcode banning and storage access rules described in [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562).
 
 [Block validation](#execution-layer-block-validation) takes roughly the same amount of work as without AA transactions.
 In any case, validation must execute the entire block in order to verify the state change.
@@ -578,7 +578,7 @@ If included, such a block is considered invalid.
 
 Passing `validUntil = 0` and `validAfter = 0` disables the check.
 
-### Calculation of Transaction Type AA_TX_TYPE hash
+### Calculation of Transaction Type `AA_TX_TYPE` hash
 
 ```
 
@@ -653,7 +653,7 @@ Any code that expects a single top-level execution frame for an Ethereum transac
 the new transaction type.
 
 [EIP-3607](https://eips.ethereum.org/EIPS/eip-3607) introduces a ban on transactions from senders with deployed code.
-This limitation does not apply to AA_TX_TYPE transactions.
+This limitation does not apply to `AA_TX_TYPE` transactions.
 
 ### Migration path for existing ERC-4337 projects and further roadmap
 
@@ -722,10 +722,10 @@ in the order they are received.
 
 As part of the mitigation, the AA transactions SHOULD be bound by storage access rules to avoid
 DoS on block builders.
-These rules are defined in [ERC-7562](https://eips.ethereum.org/EIPS/eips/eip-7562).
+These rules are defined in [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562).
 
 The full mitigation may be achieved by separating the validation from into a separate context as described in the
-[RIP-xxxx](./rip-xxxx.md).
+[RIP-7711](./rip-7711.md).
 
 ### Atomic "validate and execute" fallback function
 


### PR DESCRIPTION
This PR fixes typos, function parameter inconsistencies, and broken links found while reading the RIP.