### PR TITLE
Fix typo in the file rip-7696.md

### DIFF
--- a/RIPS/rip-7696.md
+++ b/RIPS/rip-7696.md
@@ -116,7 +116,7 @@ The `ecMulmuladd_b4` precompiled contract is proposed with the following input a
 
 ### Implementation
 
-The node is free to implement the elliptic computations as it see fit (choice of inner elliptic point reprensentation, ladder, etc). For perfomances reasons, it is recommended to use Montgomery multiplication in combination with the so called Strauss-Shamir's trick (with a 4 dimensional version for ecmulmuladd_b4). Use of windowing and NAF can speed-up implementation further. The use of a 4 dimensional version provides a speed up equivalent to GLV (Gallant-Lambert-Vanstone) optimization. The difference being that additional off chain precomputations are required.
+The node is free to implement the elliptic computations as it see fit (choice of inner elliptic point reprensentation, ladder, etc). For performances reasons, it is recommended to use Montgomery multiplication in combination with the so called Strauss-Shamir's trick (with a 4 dimensional version for ecmulmuladd_b4). Use of windowing and NAF can speed-up implementation further. The use of a 4 dimensional version provides a speed up equivalent to GLV (Gallant-Lambert-Vanstone) optimization. The difference being that additional off chain precomputations are required.
 
 ### Precompiled Contract Gas Usage
 


### PR DESCRIPTION
# Pull Request: Fix Typo in RIP-7696

## Description
This pull request addresses a typo in the `rip-7696.md` file within the repository. The word **"perfomances"** has been corrected to **"performances"** in the following context:

### Before:
> For **perfomances** reasons, it is recommended to use Montgomery multiplication...

### After:
> For **performances** reasons, it is recommended to use Montgomery multiplication...


