### PR TITLE
RIP-7859: overhaul -> Expose L1 origin information inside L2 execution environment

### DIFF
--- a/RIPS/rip-7859.md
+++ b/RIPS/rip-7859.md
@@ -3,7 +3,7 @@ rip: 7859
 title: Expose L1 origin information inside L2 execution environment
 description: Standardize the commitment of L1 origin data and historic L2 block hashes in L2 state
 author: Ian Norden (@i-norden), Bo Du (@notbdu), Christian Angelopoulos (@christianangelopoulos), Mark Tyneway (@tynes)
-discussions-to: tbd
+discussions-to: https://ethereum-magicians.org/t/rip-7859-expose-l1-origin-information-inside-l2-execution-environment/22855
 status: Draft
 type: Standards Track
 category: Core

--- a/RIPS/rip-7859.md
+++ b/RIPS/rip-7859.md
@@ -13,14 +13,14 @@ requires:
 
 ## Abstract
 
-Pre-deployed smart contract that provides access to information about the L1 block that an L2 block derives from inside
-the L2 execution environment.
+Pre-deployed smart contract for exposing inside the L2 execution environment information about the L1 blocks that the L2
+most recently included bridge inputs from.
 
 ## Motivation
 
 L2 blocks are composed of both L2 transactions sent directly to the sequencer and transactions that derive from
 deposit transactions to the native bridge on the L1. The inclusion of L1 deposit inputs into an L2 block creates
-a mapping between L2 blocks and the L1 blocks they derive from. The latest L1 block to contribute to the state of
+a mapping between L2 blocks and the L1 blocks they are produced from. The latest L1 block to contribute to the state of
 an L2 block is called that L2 block's `L1_ORIGIN`.
 
 By including information about the `L1_ORIGIN` in the L2 execution environment and making it accessible to other
@@ -162,6 +162,17 @@ when they need to rollback due to a reorg on the L1.
 of the returned values.
 
 Taken together, we believe that it would be best to both support L1SLOAD and expose an `L1_ORIGIN` view inside the VM.
+
+### Meaning in the context of an L3
+An L3 can be thought of as an L2 of an L2, in this context the `L1_ORIGIN` is instead an `L2_ORIGIN`. The same
+information about the `L2_ORIGIN` can be exposed inside the L3 execution environment and the invariant rules for the
+meaning of the `L2_ORIGIN` are the same as defined for the `L1_ORIGIN` here.
+
+Inside the L3 it is possible to access `L1_ORIGIN` info through the `L2_ORIGIN` view since it commits to the
+`L1_ORIGIN` inside the L2. This access will be specific to how the `L1_ORIGIN` data is represented in the L2's storage
+and will require providing MMPT proofs opening the `L2_ORIGIN` state root down to where the `L1_ORIGIN` information
+is stored. For this reason, it may be advantageous to support both an `L1_ORIGIN` and `L2_ORIGIN` contract interface
+inside an L3.
 
 ## Backwards Compatibility
 

--- a/RIPS/rip-7859.md
+++ b/RIPS/rip-7859.md
@@ -1,9 +1,9 @@
 ---
 rip: 7859
-title: Store L1 origin data and historic L2 block hashes in L2 state
+title: Expose L1 origin information inside L2 execution environment
 description: Standardize the commitment of L1 origin data and historic L2 block hashes in L2 state
-author: Ian Norden (@i-norden), Bo Du (@notbdu)
-discussions-to: 
+author: Ian Norden (@i-norden), Bo Du (@notbdu), Christian Angelopoulos (@christianangelopoulos), Mark Tyneway (@tynes)
+discussions-to: tbd
 status: Draft
 type: Standards Track
 category: Core
@@ -13,367 +13,173 @@ requires:
 
 ## Abstract
 
-In every L2 block store the block hash for the L1 block that the L2 block derives inputs from in a ring buffer inside
-a pre-deployed smart contract. This ring buffer will hold the last `L1_ORIGIN_BUFFER_LENGTH` number of origin hashes and
-will be referred to as the **L1 origin storage contract**.
-
-Additionally, in every L2 block store the last `L2_HISTORY_BUFFER_LENGTH` historical L2 block hashes in a ring buffer
-inside a pre-deployed smart contract. This contract will be referred to as the **L2 history storage contract**.
+Pre-deployed smart contract that provides access to information about the L1 block that an L2 block derives from inside
+the L2 execution environment.
 
 ## Motivation
 
-This RIP is the combination of [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) unmodified and
-[EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) with minor modification to store a hash of a subset of
-an L2 block's L1 origin execution block header fields instead of beacon block roots.
+L2 blocks are composed of both L2 transactions sent directly to the sequencer and transactions that derive from
+deposit transactions to the native bridge on the L1. The inclusion of L1 deposit inputs into an L2 block creates
+a mapping between L2 blocks and the L1 blocks they derive from. The latest L1 block to contribute to the state of
+an L2 block is called that L2 block's `L1_ORIGIN`.
 
-In combination these two improvements enable L2s that settle and derive from Ethereum to verify arbitrary claims about
-Ethereum and all the other L2s that settle to Ethereum.
+By including information about the `L1_ORIGIN` in the L2 execution environment and making it accessible to other
+contracts on the L2 we unlock the capability to verify arbitrary state claims about the L1.
 
-### L1 origin storage contract
+This capability is useful for a wide range of standards including verification in cross-L2 communication such as
+[RIP-7755](./rip-7755.md), enforcing L2 consistency checks such as [RIP-7789](https://ethereum-magicians.org/t/rip-7789-cross-rollup-contingent-transactions/21402),
+and verifying reads from the L1 such as [RIP-7728](./rip-7728.md) and [ERC-3668](https://eips.ethereum.org/EIPS/eip-3668).
+In general, it is useful to any contract on the L2 that needs to verify arbitrary L1 state, storage, transaction, or
+receipt data inside the L2.
 
-Maintaining inside the L2 execution environment a view of the L1 state that a given L2 block derives from- that L2
-block's L1 origin- is broadly useful for L1<->L2 and L2<->L2 interoperability and composability.
-Some specific examples of where this is useful include: [RIP-7755](./rip-7755.md),
-[RIP-7789](https://ethereum-magicians.org/t/rip-7789-cross-rollup-contingent-transactions/21402),
-[RIP-7728](./rip-7728.md),
-[ERC-3668](https://eips.ethereum.org/EIPS/eip-3668), and verifying AVS validator set state on the L1 for purposes of
-EigenDA or Lagrange state committees or other AVS protocols. In general, it is useful to any contract on the L2 that
-needs to verify arbitrary L1 state, storage, transaction, or receipt data inside the L2.
-
-### L2 history storage contract
-
-Maintaining inside the L2 execution environment historic L2 block hashes is useful for the stated side-benefit provided
-as motivation for EIP-2935:
-
-"A side benefit of this approach could be that it allows building/validating proofs related to last
-`L2_HISTORY_BUFFER_LENGTH` ancestors directly against the current state."
-
-The value provided by this capability is increased in the context of L2s as most L2s only submit L2 outputs to the L1 at
-sparse intervals. If the `L2_HISTORY_BUFFER_LENGTH` is long enough to span the L2 outputs on the L1 then it is made
-possible for any contract on the L1 to verify arbitrary L2 state, storage, transaction, or receipt data at any L2
-height using the historical L2 block hashes stored in the L2 history storage contract of an L2 output.
+This extends to verifying claims about other L2s that settle their state into Ethereum, providing a simple mechanism
+for interoperability between L2s without additional trust assumptions. If these L2s also support an
+[EIP-2985](https://eips.ethereum.org/EIPS/eip-2935) ring buffer containing their historic block hashes then it becomes
+feasible to verify claims about their receipts and transactions even if the L2 only settles outputs sparsely.
 
 ## Specification
 
-Specification mirrors the specifications of EIP-2935 and EIP-4788 with modification of EIP-4788 such that the ring
-buffer stores a keccak256 hash of a subset of L1 execution block header fields instead of beacon block roots. 
+This specification defines the contract interface for accessing information about the current and historic `L1_ORIGIN`s
+inside the L2 execution environment as well as defines the invariants that constrain the meaning of `L1_ORIGIN`. It also
+specifies a pre-deployed contract address that should be the same across rollups.
 
-Some L2s already support EIP-4788 so to avoid a conflict we must select a different address for the pre-deployed
-contract `L1_ORIGIN_STORAGE_ADDRESS`.
+The precise mechanism by which this information is loaded into the L2 during derivation is not specified nor is the
+underlying data structure or its layout in the contract. Specification at this level is avoided in order to better
+accommodate the architectural diversity present in rollup stacks, allowing them to implement this interface as best fit
+for their system.
 
-If an L2 already supports EIP-2935 no modification to that contract is needed to support the L2 history storage
-contract. To fulfill this RIP's specification they only need to add support for the **L1 origin storage contract**.
+However, it is necessary to define some constraints on the definition of the `L1_ORIGIN` for a given L2 block so that
+the protocols and contracts that leverage this interface can operate under a set of common assumptions across
+different rollup stacks.
 
-### L1 origin storage contract
+### L1 Origin invariants
 
-| Name                      | Value                                      |
-|---------------------------|--------------------------------------------|
-| L1_ORIGIN_BUFFER_LENGTH   | 8192                                       |
-| L1_ORIGIN_SYSTEM_ADDRESS  | 0xfffffffffffffffffffffffffffffffffffffffe |
-| L1_ORIGIN_STORAGE_ADDRESS | tbd                                        |
-| L1_ORIGIN_FORK_TIMESTAMP  | variable - defined by the L2               |
+We will begin by defining some invariants on the meaning of `L1_ORIGIN`
 
-The **L1 origin storage contract** has two operations: `get` and `set`. The input itself is not used to determine which
-function to execute, for that the result of `caller` is used. If `caller` is equal to `L1_ORIGIN_STORAGE_ADDRESS` then
-the operation to perform is `set`. Otherwise, `get`.
+1. Every L2 block has an `L1_ORIGIN`.
+2. An `L1_ORIGIN` must be a canonical L1 block.
+3. For an L2 block N with timestamp/height greater than L2 block M the `L1_ORIGIN` of N must have a height/timestamp
+greater than the L1 origin of M or share the same `L1_ORIGIN`.
+4. If an L2 block includes transactions derived from L1 inputs the `L1_ORIGIN` for that L2 block must be the latest
+(highest height/timestamp) L1 block that contributed L1 inputs.
 
-##### `get`
+Notice from the above rules that two L2 blocks can share the same `L1_ORIGIN` and, in fact, this is necessary for all
+rollups that have a shorter blocktime than the L1 blocktime.
 
-* Callers provide the `timestamp` they are querying encoded as 32 bytes in big-endian format.
-* If the input is not exactly 32 bytes, the contract must revert.
-* If the input is equal to 0, the contract must revert.
-* Given `timestamp`, the contract computes the storage index in which the timestamp is stored by computing the modulo
-`timestamp % L1_ORIGIN_BUFFER_LENGTH` and reads the value.
-* If the `timestamp` does not match, the contract must revert.
-* Finally, the
-`keccak256([l1Origin.block.height, l1Origin.block.stateRoot, l1Origin.block.transactionRoot, l1Origin.block.receiptRoot])`
-associated with the timestamp is returned to the user. It is stored at
-`timestamp % L1_ORIGIN_BUFFER_LENGTH + L1_ORIGIN_BUFFER_LENGTH`.
+Notice from the above that it is not necessary that sequential `L1_ORIGIN`s are contiguous L1 blocks. That is, if an L2
+block N has L1 block M as its `L1_ORIGIN` then the `L1_ORIGIN` for L2 block N+1 does not have to be L1 block M or L1
+block M+1 but could be L1 block M+2, M+3, M+x, etc. This is in order to accommodate rollup stacks that do not maintain a
+strict mapping of every L2 blocks to an L1 block but instead only consider L1 blocks when they contain deposit
+transactions.
 
-##### `set`
+An important property that arises out of the above invariants is that the `L1_ORIGIN` for a given L2 block represents
+the latest L1 block whose reorg would necessitate a reorg of that L2 block.
 
-* Caller (the sequencer) provides
-`keccak256([l1Origin.block.height, l1Origin.block.stateRoot, l1Origin.block.transactionRoot, l1Origin.block.receiptRoot])`
-as calldata to the contract.
-* Set the storage value at `header.timestamp % L1_ORIGIN_BUFFER_LENGTH` to be `header.timestamp`
-* Set the storage value at `header.timestamp % L1_ORIGIN_BUFFER_LENGTH + L1_ORIGIN_BUFFER_LENGTH` to be `calldata[0:32]`
+### Contract interface
 
-##### Bytecode
+With these invariants in place we now define the contract interface for exposing information about the `L1_ORIGIN`.
+In defining this interface we also define _what_ information about the `L1_ORIGIN` must be exposed. We define 9 methods
+in total for the `L1OriginSource` interface. These methods provide access to current and historic `L1_ORIGIN` values that
+we believe are most useful: block hash, state root, receipt root, transaction root, and block height.
 
-The exact contract bytecode is shared below.
+```solidity
+interface L1OriginSource {
+    function getL1OriginBlockHash() external view returns (bytes32 blockHash);
+    function getL1OriginParentBeaconRoot() external view returns (bytes32 blockHash);
+    function getL1OriginStateRoot() external view returns (bytes32 stateRoot);
+    function getL1OriginReceiptRoot() external view returns (bytes32 receiptRoot);
+    function getL1OriginTransactionRoot() external view returns (bytes32 transactionRoot);
+    function getL1OriginBlockHeight() external view returns (uint256 blockHeight);
 
-```asm
-caller
-push20 0xfffffffffffffffffffffffffffffffffffffffe
-eq
-push1 0x4d
-jumpi
-
-push1 0x20
-calldatasize
-eq
-push1 0x24
-jumpi
-
-push0
-push0
-revert
-
-jumpdest
-push0
-calldataload
-dup1
-iszero
-push1 0x49
-jumpi
-
-push3 0x001fff
-dup2
-mod
-swap1
-dup2
-sload
-eq
-push1 0x3c
-jumpi
-
-push0
-push0
-revert
-
-jumpdest
-push3 0x001fff
-add
-sload
-push0
-mstore
-push1 0x20
-push0
-return
-
-jumpdest
-push0
-push0
-revert
-
-jumpdest
-push3 0x001fff
-timestamp
-mod
-timestamp
-dup2
-sstore
-push0
-calldataload
-swap1
-push3 0x001fff
-add
-sstore
-stop
+    function getL1OriginBlockHashAt(uint256 height) external view returns (bytes32 blockHash);
+    function getL1OriginParentBeaconRootAt(uint256 height) external view returns (bytes32 blockHash);
+    function getL1OriginStateRootAt(uint256 height) external view returns (bytes32 stateRoot);
+    function getL1OriginReceiptRootAt(uint256 height) external view returns (bytes32 receiptRoot);
+    function getL1OriginTransactionRootAt(uint256 height) external view returns (bytes32 transactionRoot);
+}
 ```
 
-#### Deployment
+For these latter methods providing historic data access we specify that the data be available for _at least_ the most
+recent 8192 L1 blocks.
 
-The **L1 origin storage contract** can be deployed as a pre-deployed contract.
+### Pre-deployed contract address
 
-### Block processing
-
-At the top of every L2 block where `block.timestamp >= L1_ORIGIN_FORK_TIMESTAMP` the sequencer will call
-`L1_ORIGIN_STORAGE_ADDRESS` as `L1_ORIGIN_SYSTEM_ADDRESS` with the 32-byte input of
-`keccak256([l1Origin.block.height, l1Origin.block.stateRoot, l1Origin.block.transactionRoot, l1Origin.block.receiptRoot])`,
-a gas limit of `30_000_000`, and `0` value. This will trigger the `set()` routine of the beacon roots contract.
-This is a system operation and therefore:
-
-* the call must execute to completion
-* the call does not count against the block's gas limit
-* the call does not follow the [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) burn
-semantics - no value should be transferred as part of the call
-* if no code exists at `L1_ORIGIN_STORAGE_ADDRESS`, the call must fail silently
-
-If this EIP is active in a genesis block, no system transaction may occur.
-
-`l1origin` is defined as the L1 block from which inputs were taken in order to derive the nascent L2 block. If an L2
-block is built without L1 inputs but the L2 maintains a strict mapping of L2->L1 blocks based on timestamps then the L1
-origin is the L1 block that satisfies this mapping. If an L2 block is built without L1 inputs and the L2 maintains no
-strict mapping of the L2->L1 blocks then the L1 origin remains the same as the L1 origin of the previous L2 block.
-
-The invariants are
-1. Every L2 block has an L1 origin
-2. For an L2 block N with timestamp/height greater than L2 block M the L1 origin of N must have a height/timestamp
-greater than the L1 origin of M or share the same L1 origin
-3. If an L2 block includes transactions derived from L1 inputs the L1 origin for that L2 block must be the latest
-(highest height/timestamp) L1 block that contributed L1 inputs
-
-The correctness of an L2 block according to the above invariants must be enforced at settlement time. This can be
-accomplished by codifying these constraints into an optimistic rollup's fault proof program or into a zk-rollup's
-validity circuit.
-
-Additional constraints on the L1 origin may be enforced, such as a maximum difference between an L2 block's timestamp
-and the timestamp of its L1 origin block, but these are not required.
-
-### L2 history storage contract
-
-| Name                       | Value                                      |
-|----------------------------|--------------------------------------------|
-| L2_HISTORY_BUFFER_LENGTH   | 8192                                       |
-| L2_HISTORY_SYSTEM_ADDRESS  | 0xfffffffffffffffffffffffffffffffffffffffe |
-| L2_HISTORY_STORAGE_ADDRESS | tbd                                        |
-| L2_HISTORY_FORK_TIMESTAMP  | variable - defined by the L2               |
-
-Note: an L2 could perform this upgrade incrementally such that `L1_ORIGIN_FORK_TIMESTAMP` != `L2_HISTORY_FORK_TIMESTAMP`
-
-The history contract has two operations: `get` and `set`. The `set` operation is invoked only when the `caller` is equal
-to the `L2_HISTORY_SYSTEM_ADDRESS`. Otherwise, the `get` operation is performed.
-
-#### `get`
-
-It is used from the EVM for looking up block hashes.
-
-* Callers provide the block number they are querying in a big-endian encoding.
-* If calldata is bigger than 2^64-1, revert.
-* For any output outside the range of [block.number-`L2_HISTORY_BUFFER_LENGTH`, block.number-1] return 0.
-
-#### `set`
-
-* Caller provides `l2Block.parent.hash` as calldata to the contract.
-* Set the storage value at `block.number-1 % L2_HISTORY_BUFFER_LENGTH` to be `calldata[0:32]`.
-
-#### Bytecode
-
-The exact contract bytecode is shared below.
-
-```asm
-// if system call then jump to the set operation
-caller
-push20 0xfffffffffffffffffffffffffffffffffffffffe
-eq
-push1 0x57
-jumpi
-
-// check if input > 8 byte value and revert if this isn't the case
-// the check is performed by comparing the biggest 8 byte number with
-// the call data, which is a right-padded 32 byte number.
-push8 0xffffffffffffffff
-push0
-calldataload
-gt
-push1 0x53
-jumpi
-
-// check if input > blocknumber-1 then return 0
-push1 0x1
-number
-sub
-push0
-calldataload
-gt
-push1 0x4b
-jumpi
-
-// check if blocknumber > input + 8192 then return 0, no overflow expected for input of < max 8 byte value
-push0
-calldataload
-push2 0x2000
-add
-number
-gt
-push1 0x4b
-jumpi
-
-// mod 8192 and sload
-push2 0x1fff
-push0
-calldataload
-and
-sload
-
-// load into mem and return 32 bytes
-push0
-mstore
-push1 0x20
-push0
-return
-
-// 0x4b: return 0
-jumpdest
-push0
-push0
-mstore
-push1 0x20
-push0
-return
-
-// 0x53: revert
-jumpdest
-push0
-push0
-revert
-
-// 0x57: set op - sstore the input to number-1 mod 8192
-jumpdest
-push0
-calldataload
-push2 0x1fff
-push1 0x1
-number
-sub
-and
-sstore
-
-stop
-```
-
-#### Deployment
-
-The **L2 history storage contract** can be deployed as a pre-deployed contract.
-
-### Block processing
-
-At the top of every L2 block where `block.timestamp >= L2_HISTORY_FORK_TIMESTAMP` the sequencer will call to
-`L2_HISTORY_STORAGE_ADDRESS` as `L2_HISTORY_SYSTEM_ADDRESS` with the 32-byte input of `l2Block.parent.hash`, a gas limit
-of `30_000_000`, and `0` value. This will trigger the `set()` routine of the history contract.
-
-* the call must execute to completion
-* the call does not count against the block's gas limit
-* the call does not follow the EIP-1559 burn
-semantics - no value should be transferred as part of the call
-* if no code exists at `L2_HISTORY_STORAGE_ADDRESS`, the call must fail silently
-
-Note that, it will take `L2_HISTORY_SYSTEM_ADDRESS` blocks after the EIP's activation to completely fill up the ring
-buffer. Initially the contract will only contain the parent hash of the fork block and no hashes prior to that.
+The contract exposing the interface defined above should exist at a common address across all rollups. This address is
+called the `L1_ORIGIN_CONTRACT_ADDRESS` and is set to (tdb).
 
 ## Rationale
 
-### Hash of a subset of execution block fields instead of beacon block root of full execution block hash
+### Access to individual fields vs block hash or beacon block root
 
-`keccak256([l1Origin.block.height, l1Origin.block.stateRoot, l1Origin.block.transactionRoot, l1Origin.block.receiptRoot])`
-is committed into the ring buffer in order to reduce gas costs relative to using either beacon block roots or execution
-block hashes.
+Individual header fields are exposed in order to improve UX and reduce gas costs relative to exposing only L1 block
+hashes or beacon block roots. Opening a block hash or beacon root to access individual fields within them would require
+providing the entire preimage or SSZ proof in calldata. The preimage for a block hash is 708 bytes while the SSZ proof
+for a Merkle tree with depth of 3 or greater is 160+ bytes. SSZ Merkle trees for beacon blocks on average have a depth
+of 7 or 8 levels.
 
-The preimage to this hash is the 128 byte concatenation of the four fields
-`[l1Origin.block.height, l1Origin.block.stateRoot, l1Origin.block.transactionRoot, l1Origin.block.receiptRoot]`.
-This is smaller than the 708 byte preimage of a full execution header and smaller than an SSZ proof for a Merkle tree
-with depth of 3 or greater (160+ bytes).
+To retain the ability to verify other fields of the L1 execution header or beacon block we still expose the block hash
+and beacon block root.
 
-The tradeoff is that the contents of this ring buffer can not be used to verify other fields of the L1 execution header
-or beacon block.
+### Access to historic L1 origin information
 
-### Length of the ring buffers
+In this RIP we propose an interface that allows for access not to only the current `L1_ORIGIN` information but also
+for the last 8190 `L1_ORIGIN`s. This provides a view of the latest 8191 `L1_ORIGIN`s, matching
+(and motivated by) the lengths of the ring buffers in EIP-4788 and EIP-2935. This number of L1 blocks represents one
+sync committee period (256 epochs, 8192 slots), assuming no slots are skipped.
 
-Ring buffer lengths are currently set to the lengths prescribed in EIP-2935 and EIP-4788.
+Access to historic `L1_ORIGIN` information is useful for applications that need to verify claims about historic
+transactions or receipts since transaction and receipt roots do not accumulate across blocks. It is also useful for
+verifying state and storage at accounts or slots that are overwritten across blocks. Furthermore, it is useful for
+checking that two blocks from two distinct rollups are built off the same branch of Ethereum history regardless of if
+they share the same current `L1_ORIGIN`.
 
-For the **L2 history storage contract** 8192 L2 headers corresponds to ~4.55 hours worth of L2 blocks for an L2 with
-block time of 2 seconds or ~34 minutes worth of blocks for an L2 with block time of 250 milliseconds.
-The former is enough time to span the current average L2 output interval of major L2s today (~1 hour).
-The latter is not and warrants discussing an extension of the ring buffer to accommodate L2s with faster block times or
-longer output frequencies. For this reason it may make sense to not prescribe a set length for this ring buffer as L2s
-can set the length that best fits their system.
+### Enforcing correctness of `L1_ORIGIN`
+
+Correct `L1_ORIGIN` selection and storage in the contract underlying the `L1OriginSource` interface must be enforced at
+rollup settlement time according to the invariant rules. This is accomplished by these rules being part of the
+derivation and STF logic codified into the L2 output verification logic (e.g. fault proof program or SNARK circuit).
+
+### Tradeoffs vs L1SLOAD with verification deferred to settlement time
+`L1_ORIGIN` info exposed in the EVM could be used to verify L1SLOAD calls but another way to verify L1SLOAD calls is by
+deferring verification to settlement time in a manner analogous to how the correctness of the `L1_ORIGIN` view is
+enforced at settlement time. This approach provides a tremendous gas cost saving as inclusion proofs or SNARKs do not
+need to be provided and evaluated inside the L2 EVM.
+
+If L1SLOAD is implemented with deferred verification then it provides a clear cost advantage versus using the `L1_ORIGIN`
+to read L1 storage data. Nonetheless, access to the `L1_ORIGIN` as described here exhibits some properties that
+`L1SLOAD` does not:
+
+1. It can be used to verify claims about accounts, receipts/logs, and transactions.
+2. It can be used to verify claims about historic L1 data.
+3. It can be used to check whether two rollups are building off the same Ethereum fork and enforce this as a condition
+for executing cross-rollup transactions (RIP-7789).
+4. L1SLOAD cannot operate if the L2 sequencer loses connectivity to the L1.
+5. Exposing an explicit linkage between L2 and L1 blocks in the VM can make it simpler for rollups to keep track of
+when they need to rollback due to a reorg on the L1.
+6. Exposing an explicit linkage between L2 and L1 blocks in the VM can make it simpler for external apps/entities
+(outside the L2 VM) to tell what the L1 origin is.
+7. L1SLOAD includes in its rationale a request for rollups to support an `L1_ORIGIN` view in order to enforce consistency
+of the returned values.
+
+Taken together, we believe that it would be best to both support L1SLOAD and expose an `L1_ORIGIN` view inside the VM.
 
 ## Backwards Compatibility
 
-This RIP introduces backwards incompatible changes to the block derivation and verification of an L2.
-These changes are purely additive and do not break anything related to current user activity and experience, but they do
-require changes to the L2's L1->L2 derivation process and the verification logic in their output settlement contract(s).
+This RIP is backwards compatible as it is only adding a new pre-deployed contract to the EVM.
+
+## Potential implementation approaches
+
+We avoid specifying a single implementation for this RIP but use this section to provide some examples
+for how it may be implemented.
+
+One approach would be to use ring buffer constructions as in EIP-4788 and EIP-2935 where these ring buffers store
+the `L1_ORIGIN` field values. These buffers can be updated with a system call or transaction at the top of the L2 block
+using the L1 context available to the sequencer as it processes deposits from the `L1_ORIGIN` into the nascent L2 block.
+
+Another approach would be to use a contract such as Optimism's L1Block contract that stores each L1 header fields in its
+own contract variable. This contract is the original inspiration for this RIP. In this approach the sequencer includes
+at the top of a nascent L2 block an L1 attributes transaction that calls the L1Block contract with information about the
+current `L1_ORIGIN`.
 
 ## Test Cases
 


### PR DESCRIPTION
This is an update to RIP-7859 that performs a major overhaul in light of @tynes' comment [here](https://github.com/ethereum/RIPs/pull/52#issuecomment-2591619509). This RIP now defines the interface for accessing L1 info and rules for the meaning of L1 info, rather than stipulating a specific underling EIP-4788-like ring buffer implementation.

EIP-2935 portions of this RIP have largely been removed as I believe 

1. We can use the existing EIP-2935 spec or write a new RIP for it if needed
2. Usage of EIP-2935 as envision in the original state of this RIP is more implementation detail reliant- we want to standardize the storage layout for consistent usage when verifying proofs through the L2 outputs on the L1.
3. It makes this RIP cleaner