### PR TITLE
Clarify ECDSA verification in RIP 7212

### DIFF
--- a/RIPS/rip-7212.md
+++ b/RIPS/rip-7212.md
@@ -73,13 +73,14 @@ The signature verifying algorithm takes the signed message hash, the signature c
 s1 = s^(−1) (mod n)
 
 # Recover the random point used during the signing:
+# If R' is the point at infinity, verification fails
 R' = (h * s1) * G + (r * s1) * pubKey
 
 # Take from R' its x-coordinate:
 r' = R'.x
 
 # Calculate the signature validation result by comparing whether:
-r' == r
+r' == r (mod n)
 
 ```
 


### PR DESCRIPTION
The `x` coordinate of `R` may be greater than `n`. 

The current specification of RIP-7212 compares the `x` coordinate with the signature `r` value directly (as integers, presumably), which may return `false` when the standard result should be `true`

This happens with negligible probability for honest signatures, but a malicious signature can be constructed which triggers this case. Disagreement could cause differing behavior on various EVM chains.

Similarly, it is not specified what should happen when the recovered `R'` is the point at infinity. Most implementations will likely fail (correctly) but some may incorrectly treat `R'.x` as `0`.